### PR TITLE
feat: creación de DTOs para Categorías y Productos con métodos Create y CreateRange


### DIFF
--- a/ProductManager.API/Controllers/CategoryController.cs
+++ b/ProductManager.API/Controllers/CategoryController.cs
@@ -6,6 +6,7 @@ using ProductManager.Application.Categories.Commands.UpdateCategory;
 using ProductManager.Application.Categories.Queries.GetAllCategory;
 using ProductManager.Application.Categories.Queries.GetCategoryById;
 using ProductManager.Application.Common.Response;
+using ProductManager.Application.DTO;
 using ProductManager.Domain.Entities;
 
 namespace ProductManager.API.Controllers
@@ -22,44 +23,44 @@ namespace ProductManager.API.Controllers
         }
 
         [HttpGet("getAll")]
-        public async Task<ActionResult<Result<IEnumerable<Category>>>> GetAll()
+        public async Task<ActionResult<Result<IEnumerable<CategoryDTO>>>> GetAll()
         {
             var command = new GetAllCategoryCommand();
-            var result = _mediator.Send(command);
+            var result = await _mediator.Send(command);
 
             return Ok(result);
         }
 
         [HttpGet("getById/{id}")]
-        public async Task<ActionResult<Result<Category>>> GetById(Guid id)
+        public async Task<ActionResult<Result<CategoryDTO>>> GetById(Guid id)
         {
             var command = new GetCategoryByIdCommand(id);
-            var result = _mediator.Send(command);
+            var result = await _mediator.Send(command);
 
             return Ok(result);
         }
 
         [HttpPost]
-        public async Task<ActionResult<Result<Category>>> Greate(CreateCategoryCommand command)
+        public async Task<ActionResult<Result<CategoryDTO>>> Greate(CreateCategoryCommand command)
         {
-            var result = _mediator.Send(command);
+            var result = await _mediator.Send(command);
 
             return Ok(result);
         }
 
         [HttpPut]
-        public async Task<ActionResult<Result<Category>>> Update(UpdateCategoryCommand command)
+        public async Task<ActionResult<Result<CategoryDTO>>> Update(UpdateCategoryCommand command)
         {
-            var result = _mediator.Send(command);
+            var result = await _mediator.Send(command);
 
             return Ok(result);
         }
 
         [HttpDelete("delete/{id}")]
-        public async Task<ActionResult<Result<Category>>> delete(Guid id)
+        public async Task<ActionResult<Result<CategoryDTO>>> delete(Guid id)
         {
             var command = new DeleteCategoryCommand(id);
-            var result = _mediator.Send(command);
+            var result =await _mediator.Send(command);
 
             return Ok(result);
         }

--- a/ProductManager.Application/Categories/Queries/GetAllCategory/GetAllCategoryCommand.cs
+++ b/ProductManager.Application/Categories/Queries/GetAllCategory/GetAllCategoryCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using ProductManager.Application.Common.Response;
+using ProductManager.Application.DTO;
 using ProductManager.Domain.Entities;
 using System;
 using System.Collections.Generic;
@@ -9,6 +10,6 @@ using System.Threading.Tasks;
 
 namespace ProductManager.Application.Categories.Queries.GetAllCategory
 {
-    public record GetAllCategoryCommand():IRequest<Result<IEnumerable<Category>>>;
+    public record GetAllCategoryCommand():IRequest<Result<IEnumerable<CategoryDTO>>>;
 
 }

--- a/ProductManager.Application/Categories/Queries/GetAllCategory/GetAllCategoryHandler.cs
+++ b/ProductManager.Application/Categories/Queries/GetAllCategory/GetAllCategoryHandler.cs
@@ -1,16 +1,13 @@
 ﻿using MediatR;
 using ProductManager.Application.Common.Response;
+using ProductManager.Application.DTO;
 using ProductManager.Domain.Entities;
 using ProductManager.Domain.Repositories;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 
 namespace ProductManager.Application.Categories.Queries.GetAllCategory
 {
-    public class GetAllCategoryHandler : IRequestHandler<GetAllCategoryCommand, Result<IEnumerable<Category>>>
+    public class GetAllCategoryHandler : IRequestHandler<GetAllCategoryCommand, Result<IEnumerable<CategoryDTO>>>
     {
         private readonly IRepository<Category> _categoryRepository;
         public GetAllCategoryHandler(IRepository<Category> categoryRepository)
@@ -18,11 +15,15 @@ namespace ProductManager.Application.Categories.Queries.GetAllCategory
             _categoryRepository = categoryRepository;
         }
 
-        public async Task<Result<IEnumerable<Category>>> Handle(GetAllCategoryCommand request, CancellationToken cancellationToken)
+        public async Task<Result<IEnumerable<CategoryDTO>>> Handle(GetAllCategoryCommand request, CancellationToken cancellationToken)
         {
-            var result = await _categoryRepository.GetAllAsync();
 
-            return Result<IEnumerable<Category>>.Success(result);
+            var queryResult = await _categoryRepository.GetAllAsync();
+
+            var dtoElements= CategoryDTO.CreateRange(queryResult);
+
+            return Result<IEnumerable<CategoryDTO>>.Success(dtoElements);
+
         }
     }
 }

--- a/ProductManager.Application/Categories/Queries/GetCategoryById/GetCategoryByIdCommand.cs
+++ b/ProductManager.Application/Categories/Queries/GetCategoryById/GetCategoryByIdCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MediatR;
 using ProductManager.Application.Common.Response;
+using ProductManager.Application.DTO;
 using ProductManager.Domain.Entities;
 using System;
 using System.Collections.Generic;
@@ -9,5 +10,5 @@ using System.Threading.Tasks;
 
 namespace ProductManager.Application.Categories.Queries.GetCategoryById
 {
-    public record GetCategoryByIdCommand(Guid id):IRequest<Result<Category>>;
+    public record GetCategoryByIdCommand(Guid id):IRequest<Result<CategoryDTO>>;
 }

--- a/ProductManager.Application/Categories/Queries/GetCategoryById/GetCategoryByIdHandler.cs
+++ b/ProductManager.Application/Categories/Queries/GetCategoryById/GetCategoryByIdHandler.cs
@@ -1,6 +1,7 @@
 ﻿using MediatR;
 using ProductManager.Application.Common.Exceptions;
 using ProductManager.Application.Common.Response;
+using ProductManager.Application.DTO;
 using ProductManager.Domain.Entities;
 using ProductManager.Domain.Repositories;
 using System;
@@ -11,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace ProductManager.Application.Categories.Queries.GetCategoryById
 {
-    public class GetCategoryByIdHandler:IRequestHandler<GetCategoryByIdCommand,Result<Category>>
+    public class GetCategoryByIdHandler:IRequestHandler<GetCategoryByIdCommand,Result<CategoryDTO>>
     {
 
         private readonly IRepository<Category> _categoryRepository;
@@ -21,13 +22,13 @@ namespace ProductManager.Application.Categories.Queries.GetCategoryById
             _categoryRepository = categoryRepository;
         }
 
-        public async Task<Result<Category>> Handle(GetCategoryByIdCommand request,CancellationToken cancellationToken)
+        public async Task<Result<CategoryDTO>> Handle(GetCategoryByIdCommand request,CancellationToken cancellationToken)
         {
             var existCategory = await _categoryRepository.GetByIdAsync(request.id);
 
             if (existCategory == null) throw new NotFoundException("Category not found!.");
 
-            return Result<Category>.Success(existCategory);
+            return Result<CategoryDTO>.Success(CategoryDTO.Create(existCategory));
         }
     }
 }

--- a/ProductManager.Application/DTO/CategoryDTO.cs
+++ b/ProductManager.Application/DTO/CategoryDTO.cs
@@ -1,12 +1,48 @@
-﻿using System;
+﻿using ProductManager.Domain.Common;
+using ProductManager.Domain.Entities;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace ProductManager.Application.DTO
 {
-    internal class CategoryDTO
+    public class CategoryDTO
     {
+        public Guid Id { get; set; }
+        public string Name { get; set; } 
+        public EntityStatus Status { get; set; }
+        public CategoryDTO(Guid id,string name,EntityStatus status)
+        {
+            Id = id;
+            Name=name;  
+            Status = status;
+        }
+        public static CategoryDTO Create(Category category) => new CategoryDTO(category.Id, category.Name.Value, category.Status);
+        public static IEnumerable<CategoryDTO> CreateRange(IEnumerable<Category> categories)
+        {
+            try
+            {
+                
+                if (!categories.Any())
+                    return new List<CategoryDTO>();
+
+                var elements = new List<CategoryDTO>();
+
+                foreach(Category item in categories)
+                {
+                    elements.Add(CategoryDTO.Create(item)); 
+
+                }
+                return elements;
+            }
+            catch (Exception ex)
+            {
+
+                return new List<CategoryDTO>();
+            }
+        }
     }
 }

--- a/ProductManager.Application/DTO/ProductDTO.cs
+++ b/ProductManager.Application/DTO/ProductDTO.cs
@@ -29,5 +29,28 @@ namespace ProductManager.Application.DTO
                 Status = product.Status
             };
         }
+        public static IEnumerable<ProductDTO> CreateRange(IEnumerable<Product> product)
+        {
+            try
+            {
+
+                if (!product.Any())
+                    return new List<ProductDTO>();
+
+                var elements = new List<ProductDTO>();
+
+                foreach (Product item in product)
+                {
+                    elements.Add(ProductDTO.Create(item));
+
+                }
+                return elements;
+            }
+            catch (Exception ex)
+            {
+
+                return new List<ProductDTO>();
+            }
+        }
     }
 }

--- a/ProductManager.Application/Products/Queries/GetAllProduct/GetAllProductQueryHandler.cs
+++ b/ProductManager.Application/Products/Queries/GetAllProduct/GetAllProductQueryHandler.cs
@@ -24,15 +24,7 @@ namespace ProductManager.Application.Products.Queries.GetAllProduct
         {
             var items = await _repository.GetAllAsync();
 
-           var dtoElements= items.Select( x=> new ProductDTO
-            {
-                CategogyId=x.CategoryId,
-                Id=x.Id,
-                InStock=x.InStock,
-                Status=x.Status,
-                Price=x.Price.Value,
-                Name=x.Name.Value
-            });
+            var dtoElements = ProductDTO.CreateRange(items);
 
             return Result<IEnumerable < ProductDTO >>.Success(dtoElements);
         }

--- a/ProductManager.Domain/Entities/Category.cs
+++ b/ProductManager.Domain/Entities/Category.cs
@@ -1,11 +1,6 @@
 ﻿using ProductManager.Domain.Common;
 using ProductManager.Domain.ValueObjects.Category;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+
 
 namespace ProductManager.Domain.Entities
 {
@@ -14,15 +9,22 @@ namespace ProductManager.Domain.Entities
         public CategoryName Name { get; set; }
         public ICollection<Product> Products { get; set; }
 
-        public Category(CategoryName name) 
+        public Category(CategoryName name, EntityStatus status = EntityStatus.Enabled)
         {
-            Name =name;
+            Name = name;
+            Status = status;
+        }
+
+        public Category(string name, EntityStatus status = EntityStatus.Enabled)
+        {
+            Name = CategoryName.Create(name);
+            Status = status;
         }
         public Category() 
         {
         
         }
 
-        public static Category Create(string name) => new Category { Name = CategoryName.Create(name) };
+        public static Category Create(string name, EntityStatus status = EntityStatus.Enabled) => new Category { Name = CategoryName.Create(name),Status=status };
     }
 }


### PR DESCRIPTION
Cambios realizados:

Se crearon los DTOs CategoryDTO y ProductDTO.

Se agregaron los métodos estáticos Create y CreateRange para facilitar la conversión desde entidades.

Se encapsuló la lógica de mapeo desde entidad a DTO dentro de los propios DTOs.

Se solucionaron errores de serialización causados por Value Objects (CategoryName, etc.).

Se mejoró la estabilidad del endpoint de categorías evitando referencias circulares y errores de materialización.

Motivación:

Esta mejora permite desacoplar completamente la capa de presentación de las entidades de dominio. Los métodos Create/CreateRange centralizan el mapeo y mejoran la legibilidad en los handlers. Además, se eliminan los errores de serialización en System.Text.Json y Newtonsoft.Json, especialmente al trabajar con Value Objects complejos.